### PR TITLE
fix: add qiushi sidebar section

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -76,6 +76,7 @@ export default defineConfig({
               label: "公共基础与通识课程",
               autogenerate: { directory: "course/common" },
             },
+            { label: "求实书院", autogenerate: { directory: "course/qiushi" } },
             { label: "软件学院", autogenerate: { directory: "course/se" } },
             {
               label: "国际信息与软件学院",


### PR DESCRIPTION
## Summary
- add a dedicated `求实书院` sidebar section under `课程攻略`
- expose the recently added `course/qiushi/*` pages through the main navigation

## Verification
- npm run build
